### PR TITLE
Auto TP to Waypoint and Superjump

### DIFF
--- a/src/core/byte_patch_manager/byte_patch_manager.cpp
+++ b/src/core/byte_patch_manager/byte_patch_manager.cpp
@@ -7,7 +7,7 @@ namespace YimMenu
 		// put patches here
 		// example usage:
 		//
-		//BytePatch::Make(Pointers.GetLocalPed,0).get()
+		//BytePatch::Make(Pointers.GetLocalPed,0)->apply();
 
 		LOG(INFO) << "Byte patch manager initialized";
 	}

--- a/src/core/byte_patch_manager/byte_patch_manager.hpp
+++ b/src/core/byte_patch_manager/byte_patch_manager.hpp
@@ -10,6 +10,11 @@ namespace YimMenu
 
 		static void Init();
 
+		//store created patches here for dynamic enabling/disabling
+		struct Patches
+		{
+		};
+
 	private:
 		static Byte_Patch_Manager& GetInstance()
 		{

--- a/src/game/features/self/AutoTP.cpp
+++ b/src/game/features/self/AutoTP.cpp
@@ -1,0 +1,22 @@
+#include "core/commands/LoopedCommand.hpp"
+#include "game/features/Features.hpp"
+#include "util/teleport.hpp"
+
+namespace YimMenu::Features
+{
+	class AutoTP : public LoopedCommand
+	{
+		using LoopedCommand::LoopedCommand;
+
+		virtual void OnTick() override
+		{
+			Vector3 coords = Teleport::GetWaypointCoords();
+			if (coords != Vector3{0, 0, 0})
+			{
+				Teleport::TeleportEntity(YimMenu::Self::PlayerPed, rage::fvector3{coords.x, coords.y, coords.z}, true);
+			}
+		}
+	};
+
+	static AutoTP _AutoTP{"autotp", "Auto TP to Waypoint", "Automatically teleports you when you place a waypoint"};
+}

--- a/src/game/features/self/AutoTP.cpp
+++ b/src/game/features/self/AutoTP.cpp
@@ -10,10 +10,13 @@ namespace YimMenu::Features
 
 		virtual void OnTick() override
 		{
-			Vector3 coords = Teleport::GetWaypointCoords();
-			if (coords != Vector3{0, 0, 0})
+			if (MAP::IS_WAYPOINT_ACTIVE())
 			{
-				Teleport::TeleportEntity(YimMenu::Self::PlayerPed, rage::fvector3{coords.x, coords.y, coords.z}, true);
+				Vector3 coords = Teleport::GetWaypointCoords();
+				if (coords != Vector3{0, 0, 0})
+				{
+					Teleport::TeleportEntity(YimMenu::Self::PlayerPed, rage::fvector3{coords.x, coords.y, coords.z}, true);
+				}
 			}
 		}
 	};

--- a/src/game/features/self/Superjump.cpp
+++ b/src/game/features/self/Superjump.cpp
@@ -1,0 +1,18 @@
+#include "core/commands/LoopedCommand.hpp"
+#include "game/features/Features.hpp"
+#include "game/rdr/Natives.hpp"
+
+namespace YimMenu::Features
+{
+	class Superjump : public LoopedCommand
+	{
+		using LoopedCommand::LoopedCommand;
+
+		virtual void OnTick() override
+		{
+			MISC::SET_SUPER_JUMP_THIS_FRAME(Self::Id);
+		}
+	};
+
+	static Superjump _Superjump{"superjump", "Superjump", "Jump higher than normal"};
+}

--- a/src/game/frontend/submenus/Network.cpp
+++ b/src/game/frontend/submenus/Network.cpp
@@ -1,21 +1,27 @@
 #include "Network.hpp"
+
 #include "core/commands/Commands.hpp"
 #include "core/commands/HotkeySystem.hpp"
 #include "core/commands/LoopedCommand.hpp"
+#include "core/frontend/Notifications.hpp"
+#include "game/backend/FiberPool.hpp"
 #include "game/features/Features.hpp"
 #include "game/frontend/items/Items.hpp"
+#include "game/pointers/Pointers.hpp"
+
 
 namespace YimMenu::Submenus
 {
 	Network::Network() :
 	    Submenu::Submenu("Network")
 	{
-		auto session = std::make_shared<Category>("Session");
-		auto spoofing     = std::make_shared<Category>("Spoofing");
+		auto session  = std::make_shared<Category>("Session");
+		auto spoofing = std::make_shared<Category>("Spoofing");
 		session->AddItem(std::make_shared<CommandItem>("explodeall"_J));
 		session->AddItem(std::make_shared<CommandItem>("maxhonorall"_J));
 		session->AddItem(std::make_shared<CommandItem>("minhonorall"_J));
 		spoofing->AddItem(std::make_shared<BoolCommandItem>("hidegod"_J));
+		spoofing->AddItem(std::make_shared<BoolCommandItem>("voicechatoverride"_J));
 		AddCategory(std::move(session));
 		AddCategory(std::move(spoofing));
 	}

--- a/src/game/frontend/submenus/Self.cpp
+++ b/src/game/frontend/submenus/Self.cpp
@@ -63,7 +63,8 @@ namespace YimMenu::Submenus
 		globalsGroup->AddItem(std::make_shared<BoolCommandItem>("keepclean"_J));
 		globalsGroup->AddItem(std::make_shared<BoolCommandItem>("antilasso"_J));
 		globalsGroup->AddItem(std::make_shared<BoolCommandItem>("antihogtie"_J));
-		globalsGroup->AddItem(std::make_shared<BoolCommandItem>("voicechatoverride"_J)); // TODO: move this to spoofing or network
+		globalsGroup->AddItem(std::make_shared<BoolCommandItem>("autotp"_J));
+		globalsGroup->AddItem(std::make_shared<BoolCommandItem>("superjump"_J));
 
 		toolsGroup->AddItem(std::make_shared<CommandItem>("suicide"_J));
 		toolsGroup->AddItem(std::make_shared<CommandItem>("clearcrimes"_J));

--- a/src/util/teleport.hpp
+++ b/src/util/teleport.hpp
@@ -2,8 +2,9 @@
 #include "common.hpp"
 #include "core/frontend/Notifications.hpp"
 #include "game/backend/ScriptMgr.hpp"
-#include "game/rdr/Natives.hpp"
 #include "game/rdr/Entity.hpp"
+#include "game/rdr/Natives.hpp"
+
 
 // TODO: remove this file
 
@@ -83,12 +84,13 @@ namespace YimMenu::Teleport
 		return true;
 	}
 
-	inline Vector3 GetWaypointCoords()
+	inline Vector3 GetWaypointCoords(bool showNotification = false)
 	{
 		if (MAP::IS_WAYPOINT_ACTIVE())
 			return MAP::_GET_WAYPOINT_COORDS();
 
-		Notifications::Show("Waypoint", "You don't have a waypoint set", NotificationType::Error);
+		if (showNotification)
+			Notifications::Show("Waypoint", "You don't have a waypoint set", NotificationType::Error);
 
 		return Vector3{0, 0, 0};
 	}

--- a/src/util/teleport.hpp
+++ b/src/util/teleport.hpp
@@ -84,13 +84,10 @@ namespace YimMenu::Teleport
 		return true;
 	}
 
-	inline Vector3 GetWaypointCoords(bool showNotification = false)
+	inline Vector3 GetWaypointCoords()
 	{
 		if (MAP::IS_WAYPOINT_ACTIVE())
 			return MAP::_GET_WAYPOINT_COORDS();
-
-		if (showNotification)
-			Notifications::Show("Waypoint", "You don't have a waypoint set", NotificationType::Error);
 
 		return Vector3{0, 0, 0};
 	}


### PR DESCRIPTION
Also changes the bytepatch example and adds a struct to store created patches. Sort of like how pointers work and how they are stored and assigned. 
This also moves voice chat override to spoofing section.

closes #91 