### PR TITLE
Spoofed Name Detector + Protections Settings Tab

### DIFF
--- a/src/game/features/Features.cpp
+++ b/src/game/features/Features.cpp
@@ -91,17 +91,13 @@ namespace YimMenu
 		});
 	}
 
-	bool TryFirstLoad()
+	void TryFirstLoad()
 	{
 		if (!Features::_IsFirstLoadComplete.GetState())
 		{
 			Commands::GetCommand<BoolCommand>("detectspoofednames"_J)->SetState(true);
 			Features::_IsFirstLoadComplete.SetState(true);
-
-			return true;
 		}
-
-		return false;
 	}
 
 	void FeatureLoop()

--- a/src/game/features/Features.cpp
+++ b/src/game/features/Features.cpp
@@ -1,14 +1,22 @@
 #include "Features.hpp"
-#include "game/rdr/Natives.hpp"
+
+#include "core/commands/BoolCommand.hpp"
 #include "core/commands/Commands.hpp"
 #include "core/commands/HotkeySystem.hpp"
 #include "core/frontend/Notifications.hpp"
 #include "game/backend/FiberPool.hpp"
-#include "game/backend/ScriptMgr.hpp"
 #include "game/backend/Players.hpp"
-#include "game/rdr/Enums.hpp"
-#include "game/frontend/GUI.hpp"
+#include "game/backend/ScriptMgr.hpp"
 #include "game/frontend/ContextMenu.hpp"
+#include "game/frontend/GUI.hpp"
+#include "game/rdr/Enums.hpp"
+#include "game/rdr/Natives.hpp"
+
+
+namespace YimMenu::Features
+{
+	BoolCommand _IsFirstLoadComplete{"firstloadcomplete", "Is First Load Complete", "Used to detect if the first load has been completed or not."};
+}
 
 namespace YimMenu
 {
@@ -83,8 +91,23 @@ namespace YimMenu
 		});
 	}
 
+	bool TryFirstLoad()
+	{
+		if (!Features::_IsFirstLoadComplete.GetState())
+		{
+			Commands::GetCommand<BoolCommand>("detectspoofednames"_J)->SetState(true);
+			Features::_IsFirstLoadComplete.SetState(true);
+
+			return true;
+		}
+
+		return false;
+	}
+
 	void FeatureLoop()
 	{
+		TryFirstLoad();
+
 		while (true)
 		{
 			Players::Tick();

--- a/src/game/frontend/submenus/Self.cpp
+++ b/src/game/frontend/submenus/Self.cpp
@@ -8,8 +8,8 @@
 #include "game/features/Features.hpp"
 #include "game/frontend/items/Items.hpp"
 #include "game/rdr/Natives.hpp"
-#include "util/Rewards.hpp"
 #include "util/Ped.hpp"
+#include "util/Rewards.hpp"
 
 #include <map>
 

--- a/src/game/frontend/submenus/Settings.cpp
+++ b/src/game/frontend/submenus/Settings.cpp
@@ -1,10 +1,10 @@
 #include "settings.hpp"
+
 #include "core/commands/Commands.hpp"
 #include "core/commands/HotkeySystem.hpp"
 #include "core/commands/LoopedCommand.hpp"
-#include "game/frontend/items/Items.hpp"
-#include "Settings.hpp"
 #include "game/features/Features.hpp"
+#include "game/frontend/items/Items.hpp"
 
 namespace YimMenu::Submenus
 {
@@ -13,7 +13,7 @@ namespace YimMenu::Submenus
 	{
 		ImGui::BulletText("Hold the command name clicked to change its hotkey");
 		ImGui::BulletText("Press any registered key to remove");
-		
+
 		ImGui::Spacing();
 		ImGui::Separator();
 		ImGui::Spacing();
@@ -34,12 +34,15 @@ namespace YimMenu::Submenus
 	Settings::Settings() :
 	    Submenu::Submenu("Settings")
 	{
-		auto hotkeys = std::make_shared<Category>("Hotkeys");
-		auto gui = std::make_shared<Category>("GUI");
+		auto hotkeys     = std::make_shared<Category>("Hotkeys");
+		auto gui         = std::make_shared<Category>("GUI");
+		auto protections = std::make_shared<Category>("Protection");
 		hotkeys->AddItem(std::make_shared<ImGuiItem>(Hotkeys));
 		gui->AddItem(std::make_shared<BoolCommandItem>("esp"_J));
 		gui->AddItem(std::make_shared<BoolCommandItem>("ctxmenu"_J));
+		protections->AddItem(std::make_shared<BoolCommandItem>("detectspoofednames"_J));
 		AddCategory(std::move(hotkeys));
 		AddCategory(std::move(gui));
+		AddCategory(std::move(protections));
 	}
 }

--- a/src/game/hooks/Info/PlayerJoinLeave.cpp
+++ b/src/game/hooks/Info/PlayerJoinLeave.cpp
@@ -1,8 +1,16 @@
-#include "core/hooking/DetourHook.hpp"
-#include "game/hooks/Hooks.hpp"
+#include "core/commands/BoolCommand.hpp"
 #include "core/frontend/Notifications.hpp"
+#include "core/hooking/DetourHook.hpp"
+#include "game/features/Features.hpp"
+#include "game/hooks/Hooks.hpp"
 #include "game/rdr/Natives.hpp"
 #include "network/CNetGamePlayer.hpp"
+
+
+namespace YimMenu::Features
+{
+	BoolCommand _DetectSpoofedNames{"detectspoofednames", "Detect Spoofed Names", "Detects If a Player is Possibly Spoofing Their Name"};
+}
 
 namespace YimMenu::Hooks
 {
@@ -10,6 +18,8 @@ namespace YimMenu::Hooks
 	{
 		BaseHook::Get<Info::PlayerHasJoined, DetourHook<decltype(&Info::PlayerHasJoined)>>()->Original()(player);
 
+		if (player->GetName()[0] == '~' && Features::_DetectSpoofedNames.GetState())
+			Notifications::Show("Spoofed Name Detected", std::string("Spoofed Name Detected from ").append(player->GetName()), NotificationType::Warning);
 		LOG(INFO) << player->GetName() << " is joining your session.";
 	}
 

--- a/src/game/hooks/Info/PlayerJoinLeave.cpp
+++ b/src/game/hooks/Info/PlayerJoinLeave.cpp
@@ -7,32 +7,6 @@
 #include "network/CNetGamePlayer.hpp"
 
 
-namespace YimMenu
-{
-	std::string RemoveColorFromName(std::string name)
-	{
-		std::string::size_type start_pos = 0;
-		std::string newstr               = name;
-
-		while ((start_pos = newstr.find("~", start_pos)) != std::string::npos)
-		{
-			std::string::size_type end_pos = newstr.find("~", start_pos + 1);
-
-			if (end_pos != std::string::npos)
-			{
-				newstr.erase(start_pos, end_pos - start_pos + 1);
-			}
-			else
-			{
-				break;
-			}
-		}
-
-		return newstr;
-	}
-
-}
-
 namespace YimMenu::Features
 {
 	BoolCommand _DetectSpoofedNames{"detectspoofednames", "Detect Spoofed Names", "Detects If a Player is Possibly Spoofing Their Name"};
@@ -45,9 +19,7 @@ namespace YimMenu::Hooks
 		BaseHook::Get<Info::PlayerHasJoined, DetourHook<decltype(&Info::PlayerHasJoined)>>()->Original()(player);
 
 		if (player->GetName()[0] == '~' && Features::_DetectSpoofedNames.GetState())
-			Notifications::Show("Spoofed Name Detected",
-			    std::string("Spoofed Name Detected from ").append(RemoveColorFromName(player->GetName())),
-			    NotificationType::Warning);
+			Notifications::Show("Spoofed Name Detected", std::string("Spoofed Name Detected from ").append(player->GetName()), NotificationType::Warning);
 		LOG(INFO) << player->GetName() << " is joining your session.";
 	}
 

--- a/src/game/hooks/Info/PlayerJoinLeave.cpp
+++ b/src/game/hooks/Info/PlayerJoinLeave.cpp
@@ -7,6 +7,32 @@
 #include "network/CNetGamePlayer.hpp"
 
 
+namespace YimMenu
+{
+	std::string RemoveColorFromName(std::string name)
+	{
+		std::string::size_type start_pos = 0;
+		std::string newstr               = name;
+
+		while ((start_pos = newstr.find("~", start_pos)) != std::string::npos)
+		{
+			std::string::size_type end_pos = newstr.find("~", start_pos + 1);
+
+			if (end_pos != std::string::npos)
+			{
+				newstr.erase(start_pos, end_pos - start_pos + 1);
+			}
+			else
+			{
+				break;
+			}
+		}
+
+		return newstr;
+	}
+
+}
+
 namespace YimMenu::Features
 {
 	BoolCommand _DetectSpoofedNames{"detectspoofednames", "Detect Spoofed Names", "Detects If a Player is Possibly Spoofing Their Name"};
@@ -19,7 +45,9 @@ namespace YimMenu::Hooks
 		BaseHook::Get<Info::PlayerHasJoined, DetourHook<decltype(&Info::PlayerHasJoined)>>()->Original()(player);
 
 		if (player->GetName()[0] == '~' && Features::_DetectSpoofedNames.GetState())
-			Notifications::Show("Spoofed Name Detected", std::string("Spoofed Name Detected from ").append(player->GetName()), NotificationType::Warning);
+			Notifications::Show("Spoofed Name Detected",
+			    std::string("Spoofed Name Detected from ").append(RemoveColorFromName(player->GetName())),
+			    NotificationType::Warning);
 		LOG(INFO) << player->GetName() << " is joining your session.";
 	}
 


### PR DESCRIPTION
Added a check to the PlayerJoin hook and added a protections tab to the settings menu because in the future we will probably want to toggle protections in a similar style to YimMenu( for example blocking cages, etc )